### PR TITLE
Add configurable debounce time

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The easiest way to configure this plugin is via [Homebridge Config UI X](https:/
     ],
     "watchGuests": true,                           // Optional. Set false to not monitor guest networks.
     "interval": 1800,                              // Optional. Polling interval used to query Unifi in seconds 
+    "debounceTime": 10000,                         // Optional. Discard changes to occupancy that occur within the threshold in seconds
     "mode": "any"                                  // Optional. Set to "any", "all" or "none".
   }
 ]

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const events = require('events');
+const Rx = require('rxjs');
+const RxOp = require('rxjs/operators');
 const UnifiEvents = require('unifi-events');
 const manifest = require('./package.json');
 
@@ -57,6 +60,15 @@ class OccupancySensor {
       return this.checkOccupancy()
     });
 
+    this.emitter = new events.EventEmitter();
+    this.observable = Rx.fromEvent(this.emitter, 'data');
+    this.observable
+      .pipe(
+        RxOp.debounceTime(30000),
+        RxOp.distinctUntilChanged()
+      ).subscribe(value => {
+        this.setOccupancyDetected(value);
+      });
     this.occupancyDetected = Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED;
     this.checkOccupancy();
     setInterval(this.checkOccupancy.bind(this), this.interval * 1000)
@@ -126,7 +138,7 @@ class OccupancySensor {
         }
       }
 
-      this.setOccupancyDetected(this.occupancyDetected)
+      this.emitter.emit('data', this.occupancyDetected);
     })
     .catch((err) => {
       this.log(`ERROR: Failed to check occupancy: ${err.message}`)
@@ -138,6 +150,7 @@ class OccupancySensor {
   }
 
   setOccupancyDetected(value) {
+    this.log(`Setting OccupancyDetected to ${value}`);
     return this.occupancyService.setCharacteristic(Characteristic.OccupancyDetected, value)
   }
 

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ class OccupancySensor {
     this.observable = Rx.fromEvent(this.emitter, 'data');
     this.observable
       .pipe(
-        RxOp.debounceTime(30000),
+        RxOp.debounceTime((config.debounceTime || 0) * 1000),
         RxOp.distinctUntilChanged()
       ).subscribe(value => {
         this.setOccupancyDetected(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,6 +306,19 @@
         "lodash": "^4.17.15"
       }
     },
+    "rxjs": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "rxjs-compat": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.6.3.tgz",
+      "integrity": "sha512-y+wUqq7bS2dG+7rH2fNMoxsDiJ32RQzFxZQE/JdtpnmEZmwLQrb1tCiItyHxdXJHXjmHnnzFscn3b6PEmORGKw=="
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -352,6 +365,11 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "homebridge-plugin"
   ],
   "dependencies": {
+    "rxjs": "^6.6.3",
+    "rxjs-compat": "^6.6.3",
     "unifi-events": "^0.4.3"
   }
 }


### PR DESCRIPTION
This PR adds an optional `debounceTime` attribute to the configuration, which when set will smooth out changes to occupancy that happen within the set threshold. In other words, if `debounceTime` is set to 10 seconds, and a device roams from one AP to another within that time period, the occupancy sensor will stay triggered and not fluctuate.

The implementation uses the built-in [debounceTime](https://rxjs.dev/api/operators/debounceTime) which requires introducing a dependency on rxjs.

Fixes #16.