### PR TITLE
Use different library to enable support for UnifiOS based devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ yarn.lock
 package-lock.json.
 /homebridge-unifi-occupancy-sensor.iml
 /.idea/
+conf/
+/*.iml
+/*.tar.gz
+/*.tgz

--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ The easiest way to configure this plugin is via [Homebridge Config UI X](https:/
     "accessory": "UniFi Occupancy Sensor",
     "name": "Occupancy Sensor",                    // Required. The name of the sensor.
     "unifi": {
-      "controller": "https://demo.ubnt.com:8443",  // Required. The url of the UniFi Controller.
+      "controller": "https://demo.ubnt.com:8443",  // Required. The url of the UniFi Controller. Use port 443 for UnifiOS
       "username": "superadmin",                    // Required. A read-only user is fine.
       "password": "password",                      // Required.
       "site": "default",                           // Optional. The UniFi site to connect to.
-      "secure": false                              // Optional. Set true to validate the SSL certificate.
+      "secure": false,                             // Optional. Set true to validate the SSL certificate.
+      "unifios": false                             // Optional. Set true if your controller runs on UnifiOS. Use port 443 as well.
     },
     "watch": [                                     // Optional - use either watch or monitor.
-      "44:00:10:f0:3e:66",                         // An array of device MAC addresses to watch for.
+      "44:00:10:f0:3e:66"
+    ],                                             // An array of device MAC addresses to watch for.
     "monitor": [
       {                                            // Optional - use either watch or monitor. 
         "device": "44:00:10:f0:3e:67",             // An array of device MAC/AP combinations to watch for.

--- a/config.schema.json
+++ b/config.schema.json
@@ -39,6 +39,10 @@
           "secure": {
             "title": "Validate the Controller SSL Certificate?",
             "type": "boolean"
+          },
+          "unifios": {
+            "title": "Does your controller run on UnifiOS?",
+            "type": "boolean"
           }
         }
       },

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ class OccupancySensor {
 
     this.unifi = new UnifiEvents({
       host: this.controller.hostname,
-      port: this.controller.port,
+      port: this.controller.port || 443,
       username: config.unifi.username,
       password: config.unifi.password,
       site: config.unifi.site || 'default',

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const UnifiEvents = require('unifi-events');
+const UnifiEvents = require('ubnt-unifi')
 const manifest = require('./package.json');
+const url = require('url');
 
 var Service, Characteristic;
 
@@ -33,26 +34,25 @@ class OccupancySensor {
     this.watchGuests = config.watchGuests;
     this.mode = config.mode || 'any';
     this.interval = config.interval || 1800;
+    this.controller = url.parse(config.unifi.controller);
 
     this.unifi = new UnifiEvents({
-      controller: config.unifi.controller,
+      host: this.controller.hostname,
+      port: this.controller.port,
       username: config.unifi.username,
       password: config.unifi.password,
       site: config.unifi.site || 'default',
-      rejectUnauthorized: config.unifi.secure || false,
+      insecure: !config.unifi.secure || true,
+      unifios: config.unifi.unifios || false,
       listen: true
     });
 
-    this.unifi.on('websocket-status', (socketLog) => {
-      this.log(socketLog)
-    });
-
-    this.unifi.on('connected', (data) => {
+    this.unifi.on('*.connected', (data) => {
       this.log.debug(`Device Connected Event Received from UniFi Controller: ${data.msg}`);
       return this.checkOccupancy()
     });
 
-    this.unifi.on('disconnected', (data) => {
+    this.unifi.on('*.disconnected', (data) => {
       this.log.debug(`Device Disconnected Event Received from UniFi Controller: ${data.msg}`);
       return this.checkOccupancy()
     });
@@ -84,7 +84,7 @@ class OccupancySensor {
   checkOccupancy() {
     this.log.debug('Getting list of connected clients from UniFi Controller...');
 
-    return this.unifi.getClients()
+    return this.unifi.get('stat/sta')
     .then((res) => {
       this.log.debug(`${res.data.length} devices are currently connected to the UniFi network, checking each one to see if any are on the watch list...`);
       let activeDevices = res.data.filter((device) => {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "homebridge-plugin"
   ],
   "dependencies": {
-    "unifi-events": "^0.4.3"
+    "ubnt-unifi": "tickez/ubnt-unifi"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-unifi-occupancy-sensor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "An occupancy sensor for Homebridge and UniFi",
   "license": "GPL-3.0",
   "author": "oznu <dev@oz.nu>",


### PR DESCRIPTION
In case UnifiOS support is desired, this should make it work. 
Please note that the library used seems not really supported any longer, but the same seems true for unifi-events. 
I added the dependency to my github fork for the time being and raised a PR with all the changes to the original maintainer of ubnt-unifi. 