### PR TITLE
Add configurable debounce time (v2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The easiest way to configure this plugin is via [Homebridge Config UI X](https:/
     ],
     "watchGuests": true,                           // Optional. Set false to not monitor guest networks.
     "interval": 1800,                              // Optional. Polling interval used to query Unifi in seconds 
+    "debounceTime": 10000,                         // Optional. Discard changes to occupancy that occur within the threshold in seconds
     "mode": "any"                                  // Optional. Set to "any", "all" or "none".
   }
 ]

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ class OccupancySensor {
     this.observable = Rx.fromEvent(this.emitter, 'data');
     this.observable
       .pipe(
-        RxOp.debounceTime(30000),
+        RxOp.debounceTime((config.debounceTime || 0) * 1000),
         RxOp.distinctUntilChanged()
       ).subscribe(value => {
         this.setOccupancyDetected(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -303,6 +303,19 @@
         "lodash": "^4.17.19"
       }
     },
+    "rxjs": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "rxjs-compat": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.6.3.tgz",
+      "integrity": "sha512-y+wUqq7bS2dG+7rH2fNMoxsDiJ32RQzFxZQE/JdtpnmEZmwLQrb1tCiItyHxdXJHXjmHnnzFscn3b6PEmORGKw=="
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -342,6 +355,11 @@
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     }
   ],
   "dependencies": {
+    "rxjs": "^6.6.3",
+    "rxjs-compat": "^6.6.3",
     "unifi-events": "^2.0.0"
   }
 }


### PR DESCRIPTION
This PR adds an optional `debounceTime` attribute to the configuration, which when set will smooth out changes to occupancy that happen within the set threshold. In other words, if `debounceTime` is set to 10 seconds, and a device roams from one AP to another within that time period, the occupancy sensor will stay triggered and not fluctuate.

The implementation uses the built-in [debounceTime](https://rxjs.dev/api/operators/debounceTime) which requires introducing a dependency on rxjs.

Fixes #16.

Resubmit of #25 rebased onto latest master.